### PR TITLE
medium link is largely unhelpful

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,3 @@ A simple REST API to upload and download files using rust language
 ## APIs
 - POST `/api/files/` Upload a file
 - GET `/api/files/{name}/` Download a file with a name
-
-## Medium related post
-You can follow my medium [Build your first REST API using Rust language and actix framework](https://medium.com/@mehrdadep/build-your-first-rest-api-using-rust-language-and-actix-framework-8f827175b30f) to find out more about this project.


### PR DESCRIPTION
This is a nice little example repo. It is a helpful piece of code for anyone learning rust that wants to see some working code and start hacking on it.

Some of the most talented people make the worst teachers, because they can't see how difficult it is to learn when everything seems to obvious to them.

The medium article by comparison is difficult to follow at best and incoherent gibberish at worst. If we compare it with https://pwy.io/en/posts/learning-to-fly-pt1/ it becomes obvious that the medium post is deficient as education for others.
I estimate that the target audience for that medium article is someone that has read The Rust Book and maybe has just finished rustlings. From the medium post they may be encouraged to abandon rust entirely.